### PR TITLE
Fixing missing default image bug

### DIFF
--- a/comicapi/comicarchive.py
+++ b/comicapi/comicarchive.py
@@ -645,8 +645,9 @@ class ComicArchive:
         if ComicArchive.logo_data is None:
             #fname = ComicTaggerSettings.getGraphic('nocover.png')
             fname = self.default_image_path
-            with open(fname, 'rb') as fd:
-                ComicArchive.logo_data = fd.read()
+            if fname is not None and os.path.isfile(fname):
+                with open(fname, 'rb') as fd:
+                    ComicArchive.logo_data = fd.read()
 
     def resetCache(self):
         """Clears the cached data"""

--- a/comictaggerlib/comicvinetalker.py
+++ b/comictaggerlib/comicvinetalker.py
@@ -528,7 +528,7 @@ class ComicVineTalker(QObject):
         if string is None:
             return ""
         # find any tables
-        soup = BeautifulSoup(string)
+        soup = BeautifulSoup(string, "lxml")
         tables = soup.findAll('table')
 
         # remove all newlines first
@@ -684,7 +684,7 @@ class ComicVineTalker(QObject):
         return alt_cover_url_list
 
     def parseOutAltCoverUrls(self, page_html):
-        soup = BeautifulSoup(page_html)
+        soup = BeautifulSoup(page_html, "lxml")
 
         alt_cover_url_list = []
 


### PR DESCRIPTION
I had a problem when using the API from an external script, which was throwing this error:

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/comictagger-1.1.15b0-py2.7.egg/comicapi/comicarchive.py", line 648, in __init__
    with open(fname, 'rb') as fd:
TypeError: coercing to Unicode: need string or buffer, NoneType found
````

This fixes that error