### PR TITLE
Add appveyor configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,6 @@
+version: 1.0.{build}
+build_script:
+- cmd: powershell -exec bypass -File windows\fullbuild.ps1
+artifacts:
+- path: dist\*.exe
+  name: ComicTagger

--- a/comictaggerlib/ctversion.py
+++ b/comictaggerlib/ctversion.py
@@ -1,3 +1,3 @@
 # This file should contain only these comments, and the line below.
 # Used by packaging makefiles and app
-version = "1.1.16-beta-rc2"
+version = "1.1.20-SNAPSHOT"

--- a/unrar/makefile
+++ b/unrar/makefile
@@ -8,13 +8,7 @@ LIBFLAGS=-fPIC
 DEFINES=-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -DRAR_SMP
 STRIP=strip
 AR=ar
-ifeq ($(OS),Windows_NT)
-	# statically compile mingw dependencies
-	# https://stackoverflow.com/questions/18138635/mingw-exe-requires-a-few-gcc-dlls-regardless-of-the-code
-	LDFLAGS=-Wl,-Bstatic,--whole-archive -lwinpthread -Wl,--no-whole-archive -pthread -static-libgcc -static-libstdc++
-else
-	LDFLAGS=-pthread
-endif
+LDFLAGS=-pthread
 DESTDIR=/usr
 
 # Linux using LCC

--- a/windows/fullbuild.ps1
+++ b/windows/fullbuild.ps1
@@ -1,0 +1,9 @@
+# Script to be run inside appveyor for a full build
+$env:PATH="C:\tools\mingw64\bin;C:\Miniconda-x64;C:\Miniconda-x64\Scripts;$env:path"
+choco install -y mingw
+C:\Miniconda-x64\Scripts\conda create -y --name comictagger python=2
+C:\Miniconda-x64\Scripts\activate comictagger
+C:\Miniconda-x64\Scripts\conda install -y pyqt=4
+C:\Miniconda-x64\Scripts\pip install -r .\requirements.txt
+mingw32-make dist
+objdump -af unrar/libunrar.so


### PR DESCRIPTION
Basic support:
 - only 64bit
 - miniconda python based
 - mingw based unrar compilation
 - very simple powershell script to run a full build
 - always successfull build (doesn't seem to catch errors) for now

Resolves #101.