### PR TITLE
Tweaked search string based on new comic vine search behavior

### DIFF
--- a/comicapi/utils.py
+++ b/comicapi/utils.py
@@ -121,7 +121,7 @@ def which(program):
 
 def removearticles(text):
     text = text.lower()
-    articles = ['and', 'the', 'a', '&', 'issue']
+    articles = ['and', 'a', '&', 'issue']
     newText = ''
     for word in text.split(' '):
         if word not in articles:

--- a/comictaggerlib/comicvinetalker.py
+++ b/comictaggerlib/comicvinetalker.py
@@ -223,17 +223,10 @@ class ComicVineTalker(QObject):
 
         original_series_name = series_name
 
-        # We need to make the series name into an "AND"ed query list
+	# Split and rejoin to remove extra internal spaces
         query_word_list = series_name.split()
-        and_list = ['AND'] * (len(query_word_list) - 1)
-        and_list.append('')
-        # zipper up the two lists
-        query_list = zip(query_word_list, and_list)
-        # flatten the list
-        query_list = [item for sublist in query_list for item in sublist]
-        # convert back to a string
-        query_string = " ".join(query_list).strip()
-        # print "Query string = ", query_string
+        query_string = " ".join( query_word_list ).strip()
+        #print "Query string = ", query_string
 
         query_string = urllib.quote_plus(query_string.encode("utf-8"))
 
@@ -532,7 +525,7 @@ class ComicVineTalker(QObject):
         if string is None:
             return ""
         # find any tables
-        soup = BeautifulSoup(string)
+        soup = BeautifulSoup(string, "html.parser")
         tables = soup.findAll('table')
 
         # remove all newlines first
@@ -688,7 +681,7 @@ class ComicVineTalker(QObject):
         return alt_cover_url_list
 
     def parseOutAltCoverUrls(self, page_html):
-        soup = BeautifulSoup(page_html)
+        soup = BeautifulSoup(page_html, "html.parser")
 
         alt_cover_url_list = []
 


### PR DESCRIPTION
The ComicVine search changes seem to have settled down.  I found that the "AND"s between search terms are no longer needed.  Also, removing "the" seems to make the seach fail sometimes too, so stopped doing that.

In addition, just a small change to keep to beautifulsoup from complaining. 