### PR TITLE
Fixed TLS version for the Comic Vine

### DIFF
--- a/comictaggerlib/comicvinetalker.py
+++ b/comictaggerlib/comicvinetalker.py
@@ -105,7 +105,7 @@ class ComicVineTalker(QObject):
         self.log_func = None
 
         # always use a tls context for urlopen
-        self.ssl = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+        self.ssl = ssl.SSLContext(ssl.PROTOCOL_TLS)
 
     def setLogFunc(self, log_func):
         self.log_func = log_func

--- a/comictaggerlib/imagefetcher.py
+++ b/comictaggerlib/imagefetcher.py
@@ -67,7 +67,7 @@ class ImageFetcher(QObject):
             self.create_image_db()
 
         # always use a tls context for urlopen
-        self.ssl = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+        self.ssl = ssl.SSLContext(ssl.PROTOCOL_TLS)
 
     def clearCache(self):
         os.unlink(self.db_file)


### PR DESCRIPTION
Comic Vine forced new version of the TLS encryption. This fix is making comictagger compliant with this change.